### PR TITLE
merge ncw and yeh

### DIFF
--- a/big_lists.py
+++ b/big_lists.py
@@ -1,7 +1,7 @@
 
 """List of large size that we've moved to an external file."""
 
-dhall_list = sorted(["CJL", "Forbes", "NCW", "RoMa", "Whitman", "Yeh"])
+dhall_list = sorted(["CJL", "Forbes", "NCW/Yeh", "RoMa", "Whitman"])
 
 
 mjr = ['African American Studies', 'Anthropology', 'Architecture',

--- a/meal_requests.py
+++ b/meal_requests.py
@@ -1,5 +1,3 @@
-from ast import Is
-from requests import get
 from database import new_connection, close_connection, update_request_usage_metric
 from matcher import match_requests
 from big_lists import dhall_list

--- a/server.py
+++ b/server.py
@@ -145,12 +145,6 @@ def form():
     return redirect('/index')
 
 
-# TEST ROUTE --- FORCE MATCHES
-@app.route('/forcematches', methods=['GET'])
-def force_matches():
-    matcher.match_requests()
-    return redirect("/matches")
-
 
 # SUBMIT REQUEST
 @app.route('/submitrequest', methods=['GET'])


### PR DESCRIPTION
Merge NCW and Yeh into 1 single option to prevent user confusion and lost potential matches

Minor changes were made to user data to prevent an error with recurring requests

past requests may still say a single res college rather than **NCW/Yeh**q